### PR TITLE
Fix SVG exporting and rendering

### DIFF
--- a/ui/src/components/Pixel.svelte
+++ b/ui/src/components/Pixel.svelte
@@ -1,4 +1,7 @@
 <style>
+  path {
+    shape-rendering: crispEdges;
+  }
   path:hover {
     stroke: gray;
   }

--- a/ui/src/lib/exportCanvas.ts
+++ b/ui/src/lib/exportCanvas.ts
@@ -1,10 +1,23 @@
+const appendCSS = element => {
+  const styleElement = document.createElement('style');
+  styleElement.setAttribute('type', 'text/css');
+  // TODO: if a theme is used (e.g. dark background) set background-color ≈
+  styleElement.innerHTML =
+    'svg { background-color: white;} path {shape-rendering: crispEdges;}';
+  const refNode = element.hasChildNodes() ? element.children[0] : null;
+  element.insertBefore(styleElement, refNode);
+  return element;
+};
+
 const parseSVG = (svgNode: SVGElement): string => {
   const mesh = document.getElementById('mesh');
-  if (mesh) mesh.setAttribute('fill', 'white');
+  let clone = svgNode.cloneNode(true) as SVGElement;
+  const g = clone.children.namedItem('hexagons');
+  if (mesh) g.removeChild(g.children.namedItem('mesh'));
+  clone = appendCSS(clone);
   //  TODO: remove non-filled pixels from the svgNode
   //
-  let serializedXML = new XMLSerializer().serializeToString(svgNode);
-  if (mesh) mesh.setAttribute('fill', '#fff0');
+  let serializedXML = new XMLSerializer().serializeToString(clone);
   serializedXML = serializedXML.replace(/(\w+)?:?xlink=/g, 'xmlns:xlink=');
   // // Safari NS namespace fix
   serializedXML = serializedXML.replace(/NS\d+:href/g, 'xlink:href');


### PR DESCRIPTION
Adds CSS to the exported SVG image with a white background and crisp path edges (also implemented for active paths)

- Fixes:
  - https://github.com/yosoyubik/canvas/issues/26 
  - https://github.com/yosoyubik/canvas/issues/25