### PR TITLE
Advanced coloring pt 1.1

### DIFF
--- a/ui/src/components/ColorPicker.svelte
+++ b/ui/src/components/ColorPicker.svelte
@@ -224,8 +224,8 @@
   export let startColor = '#FF0000';
   let mounted = false;
 
-  $: mounted && startColor && setStartColor()
-  
+  $: mounted && startColor && setStartColor();
+
   onMount(() => {
     document.addEventListener('mouseup', mouseUp);
     document.addEventListener('touchend', mouseUp);
@@ -253,9 +253,9 @@
   function setStartColor() {
     let color = d3.color(startColor);
     hexValue = color.formatHex();
-    r = color.r;
-    g = color.g;
-    b = color.b;
+    r = color.r || 255;
+    g = color.g || 255;
+    b = color.b || 255;
     a = color.opacity;
     updatePickers();
   }

--- a/ui/src/components/ColorPickerTooltip.svelte
+++ b/ui/src/components/ColorPickerTooltip.svelte
@@ -27,7 +27,11 @@
   export let color;
   export let size;
 
+  let pickerDiv;
+
   $: startColor = d3.color(color)?.formatRgb() || 'rgb(213, 62, 79)';
+  $: pickerDivOnLeftSide =
+    pickerDiv && pickerDiv.getBoundingClientRect().left <= 128;
 
   function colorCallback(event) {
     const { r, g, b, a } = event.detail;
@@ -37,8 +41,11 @@
   }
 </script>
 
-<div class="button-only-tooltip">
-  <Tooltip bind:open align="center" triggerText={undefined}>
+<div class="button-only-tooltip" bind:this={pickerDiv}>
+  <Tooltip
+    bind:open
+    align={pickerDivOnLeftSide ? 'start' : 'center'}
+    triggerText={undefined}>
     <div class={'colorPicker'}>
       <ColorPicker on:colorChange={colorCallback} {startColor} />
     </div>

--- a/ui/src/components/Header.svelte
+++ b/ui/src/components/Header.svelte
@@ -96,7 +96,9 @@
               <TooltipFooter selectorPrimaryFocus="#d">
                 <span>
                   Feedback, questions? Join
-                  <a href="/apps/landscape/perma/group/~norsyr-torryn/canvas" target="_blank">~norsyr-torryn/canvas</a>
+                  <a
+                    href="/apps/landscape/perma/group/~norsyr-torryn/canvas"
+                    target="_blank">~norsyr-torryn/canvas</a>
                   or contact ~norsyr-torryn :)
                 </span>
               </TooltipFooter>


### PR DESCRIPTION
- Allow color picker to initialize properly when given a 0-opacity "color"
- Move the color picker tooltip to the right when it's on the left of the screen
- run the linter