### PR TITLE
fix weird edge case bug by defaulting to rgba(0, 0, 0, 0), which is w…

### DIFF
--- a/ui/src/components/ColorPicker.svelte
+++ b/ui/src/components/ColorPicker.svelte
@@ -253,9 +253,9 @@
   function setStartColor() {
     let color = d3.color(startColor);
     hexValue = color.formatHex();
-    r = color.r || 255;
-    g = color.g || 255;
-    b = color.b || 255;
+    r = color.r || 0;
+    g = color.g || 0;
+    b = color.b || 0;
     a = color.opacity;
     updatePickers();
   }

--- a/ui/src/components/Pixel.svelte
+++ b/ui/src/components/Pixel.svelte
@@ -30,7 +30,7 @@
 
   const dispatch = createEventDispatcher();
   const oneDay = 1000 * 3600 * 24;
-  const defaultColor = 'rgba(255, 255, 255, 0)';
+  const defaultColor = 'rgba(0, 0, 0, 0)';
 
   $: pixelColor = data?.properties?.color
     ? d3.color(data.properties.color).formatRgb()


### PR DESCRIPTION
Default to `rgba(0, 0, 0, 0)`, which is what d3 will give for any 0-opacity color. Without this, filling sometimes doesn't work as expected because `'rgba(0, 0, 0, 0)' != 'rgba(255, 255, 255, 0)'`.

Sorry I didn't see this until after the release 😬 